### PR TITLE
Generate Python object docs from docstrings and add version number on homepage

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -4,6 +4,10 @@
 # list see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
+import sys
+import os
+from datetime import datetime
+
 # -- Path setup --------------------------------------------------------------
 
 # If extensions (or modules to document with autodoc) are in another directory,
@@ -14,13 +18,26 @@
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
 
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+sys.path.insert(0, os.path.abspath('../'))
+import frankenstein
 
 # -- Project information -----------------------------------------------------
 
-project = 'Frankenstein'
-copyright = '2020, R. Booth, J. Jenning, M. Tazzari'
-author = 'R. Booth, J. Jenning, M. Tazzari'
+project = 'frankenstein'
+authors = u'R. Booth, J. Jenning, M. Tazzari'
+copyright = '2019-%d, %s' % (datetime.now().year, authors)
 
+# The version info for the project you're documenting, acts as replacement for
+# |version| and |release|, also used in various other places throughout the
+# built documents.
+#
+# The short X.Y version.
+version = str(frankenstein.__version__)
+# The full version, including alpha/beta/rc tags.
+release = str(frankenstein.__version__)
 
 # -- General configuration ---------------------------------------------------
 
@@ -28,16 +45,32 @@ author = 'R. Booth, J. Jenning, M. Tazzari'
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
+    'sphinx.ext.mathjax',
+    'sphinx.ext.autodoc',
+    'sphinx.ext.napoleon',
+    'sphinxcontrib.fulltoc',
 ]
+
+mathjax_path = "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS_HTML"
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
+
+# The suffix(es) of source filenames.
+source_suffix = '.rst'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 
+
+# A string of reStructuredText that will be included at the beginning of every
+# source file that is read.
+rst_prolog="""
+.. |frank| replace:: **{}**
+.. default-role:: code
+""".format(project)
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -64,6 +64,7 @@ source_suffix = '.rst'
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 
+master_doc = 'index'
 
 # A string of reStructuredText that will be included at the beginning of every
 # source file that is read.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,14 +3,15 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-Welcome to Frankenstein's documentation!
-========================================
+===================
+|frank| |version|
+===================
 
 .. toctree::
    :maxdepth: 2
    :caption: Contents:
 
-
+   Python API <py_API>
 
 Indices and tables
 ==================

--- a/docs/py_API.rst
+++ b/docs/py_API.rst
@@ -1,0 +1,17 @@
+Python API reference
+====================
+
+The documentation of each function that is reported in this page can also be directly accessed from Python with, e.g.:
+
+.. code:: python
+
+    from frankenstein.radial_fitters import FrankFitter
+
+    help(FrankFitter)
+
+
+Run a fit
+~~~~~~~~~~
+To run a fit use the :func:`FrankFitter <frankenstein.radial_fitters.FrankFitter>` object.
+
+.. autofunction:: frankenstein.radial_fitters.FrankFitter

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ matplotlib
 scipy
 pytest
 sphinx
+sphinxcontrib-fulltoc


### PR DESCRIPTION
The docs/py_API.rst file shows how to refer to Python objects/functions with urls and how to generate their documentation from the docstring.
@jeffjennings @rbooth200 pls have a look at the file, so you can write the docs you want.