### PR TITLE
Store geometry

### DIFF
--- a/frankenstein/geometry.py
+++ b/frankenstein/geometry.py
@@ -217,7 +217,7 @@ class SourceGeometry(object):
         """
         return
 
-    def clone_geometry(self):
+    def clone(self):
         """Save the geometry parameters in a seperate geometry object."""
         return FixedGeometry(self.inc, self.PA, self.dRA, self.dDec)
 

--- a/frankenstein/geometry.py
+++ b/frankenstein/geometry.py
@@ -217,6 +217,10 @@ class SourceGeometry(object):
         """
         return
 
+    def clone_geometry(self):
+        """Save the geometry parameters in a seperate geometry object."""
+        return FixedGeometry(self.inc, self.PA, self.dRA, self.dDec)
+
     @property
     def dRA(self):
         """Phase centre offset in Right Ascension, units=arcsec"""

--- a/frankenstein/radial_fitters.py
+++ b/frankenstein/radial_fitters.py
@@ -479,7 +479,7 @@ class FourierBesselFitter(object):
         self._build_matrices(u, v, V, weights)
 
         self._sol = _HankelRegressor(self._DHT, self._M, self._j,
-                                     geometry=self._geometry,
+                                     geometry=self._geometry.clone(),
                                      noise_likelihood=self._H0)
 
         return self._sol
@@ -767,7 +767,7 @@ class FrankFitter(FourierBesselFitter):
 
         """
         return _HankelRegressor(self._DHT, self._M, self._j, p,
-                                geometry=self._geometry,
+                                geometry=self._geometry.clone(),
                                 noise_likelihood=self._H0)
 
     def log_prior(self, p=None):


### PR DESCRIPTION
Fixes a bug in the following code:
```
fitter = FrankFitter(Rmax, N, FitGeometryGaussian())
sol1 = fitter.fit(u1,v1,vis1, w1)
sol2 = fitter.fit(u2,v2,vis2, w2)
```

Previously the second fit would change the geometry parameters of the sol1 fit, which is not the desired behaviour. This PR fixes that issue